### PR TITLE
Update Windows path registration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,6 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Pulsar Editor
         uses: ./
-      - if: runner.os == 'Windows'
-        run: |
-          [System.Environment]::GetEnvironmentVariable("Path","Machine")
-          Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("ProgramFiles"))
-          Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)"))
-          Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))
-          if (Test-Path "$($env:LOCALAPPDATA)\Programs") { Get-ChildItem -Path "$([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))\Programs" }
-          if (Test-Path "$($env:LOCALAPPDATA)\Programs\Pulsar") { Get-ChildItem -Path "$([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))\Programs\Pulsar" }
-          pulsar -v
       - run: pulsar -v
       
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,11 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Pulsar Editor
         uses: ./
+      - if: runner.os == 'Windows'
+        run: |
+          [System.Environment]::GetEnvironmentVariable("Path","Machine")
+          [System.Environment]::GetEnvironmentVariable("Path","User")
+          $env:Path
       - run: pulsar -v
       
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,9 @@ jobs:
             [System.Environment]::GetEnvironmentVariable("Path","Machine"),
             [System.Environment]::GetEnvironmentVariable("Path","User")
           ) -join ';')
-      - run: pulsar -v
+          pulsar -v
+      - if: runner.os == 'Linux' || runner.os == 'macOS'
+        run: pulsar -v
       
         
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,15 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Pulsar Editor
         uses: ./
-      - if: runner.os == 'Windows'
-        run: |
-          $env:Path = (@(
-            [System.Environment]::GetEnvironmentVariable("Path","Machine"),
-            [System.Environment]::GetEnvironmentVariable("Path","User")
-          ) -join ';')
-          pulsar -v
-      - if: runner.os == 'Linux' || runner.os == 'macOS'
-        run: pulsar -v
+      - run: pulsar -v
       
         
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
           Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)"))
           Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))
           if (Test-Path "$($env:LOCALAPPDATA)\Programs") { Get-ChildItem -Path "$([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))\Programs" }
+          if (Test-Path "$($env:LOCALAPPDATA)\Programs\Pulsar") { Get-ChildItem -Path "$([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))\Programs\Pulsar" }
+          pulsar -v
       - run: pulsar -v
       
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,3 +15,8 @@ jobs:
       - name: Setup Pulsar Editor
         uses: ./
       - run: pulsar -v
+      - if: matrix.os == 'windows-latest'
+        run: |
+          [System.Environment]::GetEnvironmentVariable("Path","Machine")
+        
+        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ jobs:
       - if: runner.os == 'Windows'
         run: |
           [System.Environment]::GetEnvironmentVariable("Path","Machine")
+          Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("ProgramFiles"))
+          Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("ProgramFiles(x86)"))
+          Get-ChildItem -Path ([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))
+          if (Test-Path "$($env:LOCALAPPDATA)\Programs") { Get-ChildItem -Path "$([System.Environment]::GetEnvironmentVariable("LOCALAPPDATA"))\Programs" }
       - run: pulsar -v
       
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,9 +14,10 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup Pulsar Editor
         uses: ./
-      - run: pulsar -v
-      - if: matrix.os == 'windows-latest'
+      - if: runner.os == 'Windows'
         run: |
           [System.Environment]::GetEnvironmentVariable("Path","Machine")
+      - run: pulsar -v
+      
         
         

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,3 @@ jobs:
       - name: Setup Pulsar Editor
         uses: ./
       - run: pulsar -v
-      
-        
-        

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,9 +16,10 @@ jobs:
         uses: ./
       - if: runner.os == 'Windows'
         run: |
-          [System.Environment]::GetEnvironmentVariable("Path","Machine")
-          [System.Environment]::GetEnvironmentVariable("Path","User")
-          $env:Path
+          $env:Path = (@(
+            [System.Environment]::GetEnvironmentVariable("Path","Machine"),
+            [System.Environment]::GetEnvironmentVariable("Path","User")
+          ) -join ';')
       - run: pulsar -v
       
         

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ jobs:
       - name: Checkout the Latest Package Code
         uses: actions/checkout@v3
       - name: Setup Pulsar Editor
-        uses: pulsar-edit/action-pulsar-dependency@v3
+        uses: pulsar-edit/action-pulsar-dependency@v3.2
       - name: Run the headless Pulsar Tests
-        uses: GabrielBB/xvfb-action@v1
+        uses: coactions/setup-xvfb@v1.0.1
         with:
           run: pulsar --test spec
 
@@ -29,4 +29,6 @@ jobs:
 
 The above is a valid workflow for any package repository.
 
-Otherwise using `GabrielBB/xvfb-action` is recommended because otherwise the tests will attempt to startup Electron from Pulsar and fail when they are unable to connect to a display.
+Otherwise using `coactions/setup-xvfb` is recommended because otherwise the tests will attempt to startup Electron from Pulsar and fail when they are unable to connect to a display.
+
+Using `coactions/setup-xvfb` over `GabrielBB/xvfb-action` is recommended because it appears unmaintained anymore, and Nodejs 12 actions are deprecated

--- a/action.yml
+++ b/action.yml
@@ -49,5 +49,5 @@ runs:
         $env:Path = (@(
           [System.Environment]::GetEnvironmentVariable("Path","Machine"),
           [System.Environment]::GetEnvironmentVariable("Path","User")
-       ) -join ';')
-       Write-Host "User PATH updated"
+        ) -join ';')
+        Write-Host "User PATH updated"

--- a/action.yml
+++ b/action.yml
@@ -4,6 +4,9 @@ author: confused-Techie
 branding:
   icon: check-square
   color: purple
+outputs:
+  windows-path:
+    
 runs:
   using: "composite"
   steps:
@@ -35,18 +38,7 @@ runs:
         Start-Process -FilePath $downloadPath -ArgumentList '/currentuser', '/S' -Wait
         Write-Host "Pulsar Install completed"
 
-        Write-Host "Adding Pulsar and PPM directories to User PATH"
+        Write-Host "Adding Pulsar and PPM directories to GITHUB_PATH"
 
-        $existingPathData = [System.Environment]::GetEnvironmentVariable("Path","User")
-        $newPathData = @(
-          $existingPathData,
-          "$env:LOCALAPPDATA\Programs\Pulsar\",
-          "$env:LOCALAPPDATA\Programs\Pulsar\resources\app\ppm\bin\"
-        )
-        
-        [System.Environment]::SetEnvironmentVariable("Path", (($newPathData -join ';').replace(';;', ';')), [EnvironmentVariableTarget]::User )
-        $env:Path = (@(
-          [System.Environment]::GetEnvironmentVariable("Path","Machine"),
-          [System.Environment]::GetEnvironmentVariable("Path","User")
-        ) -join ';')
-        Write-Host "PATH updated: `r`nPreviously `r`n$($existingPathData)`r`nNow `r`n$([System.Environment]::GetEnvironmentVariable("Path","User"))"
+        "$env:LOCALAPPDATA\Programs\Pulsar\" >> $env:GITHUB_PATH
+        "$env:LOCALAPPDATA\Programs\Pulsar\resources\app\ppm\bin\" >> $env:GITHUB_PATH

--- a/action.yml
+++ b/action.yml
@@ -37,16 +37,16 @@ runs:
 
         Write-Host "Adding Pulsar and PPM directories to User PATH"
 
-        $existingPathData = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+        $existingPathData = [System.Environment]::GetEnvironmentVariable("Path","User")
         $newPathData = @(
           $existingPathData,
           "$env:LOCALAPPDATA\Programs\Pulsar\",
           "$env:LOCALAPPDATA\Programs\Pulsar\resources\app\ppm\bin\"
         )
         
-        [System.Environment]::SetEnvironmentVariable("Path", (($newPathData -join ';').replace(';;', ';')), [EnvironmentVariableTarget]::Machine )
+        [System.Environment]::SetEnvironmentVariable("Path", (($newPathData -join ';').replace(';;', ';')), [EnvironmentVariableTarget]::User )
         $env:Path = (@(
           [System.Environment]::GetEnvironmentVariable("Path","Machine"),
           [System.Environment]::GetEnvironmentVariable("Path","User")
         ) -join ';')
-        Write-Host "PATH updated: `r`nPreviously $($existingPathData)`r`nNow $([System.Environment]::GetEnvironmentVariable("Path","Machine"))"
+        Write-Host "PATH updated: `r`nPreviously `r`n$($existingPathData)`r`nNow `r`n$([System.Environment]::GetEnvironmentVariable("Path","User"))"

--- a/action.yml
+++ b/action.yml
@@ -4,9 +4,6 @@ author: confused-Techie
 branding:
   icon: check-square
   color: purple
-outputs:
-  windows-path:
-    
 runs:
   using: "composite"
   steps:

--- a/action.yml
+++ b/action.yml
@@ -36,18 +36,17 @@ runs:
         Write-Host "Pulsar Install completed"
 
         Write-Host "Adding Pulsar and PPM directories to User PATH"
-        $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
 
-        $existingUserPath = (Get-ItemProperty -Path $registryPath -Name path).Path
-        $newUserPath = @(
-          $existingMachinePath,
+        $existingPathData = [System.Environment]::GetEnvironmentVariable("Path","Machine")
+        $newPathData = @(
+          $existingPathData,
           "$env:LOCALAPPDATA\Programs\Pulsar",
           "$env:LOCALAPPDATA\Programs\Pulsar\resources\app\ppm\bin"
         )
         
-        Set-ItemProperty -Path $registryPath -Name path -Value (($newUserPath -join ';').replace(';;', ';'))
+        [System.Environment]::SetEnvironmentVariable("Path", (($newPathData -join ';').replace(';;', ';')), [EnvironmentVariableTarget]::Machine )
         $env:Path = (@(
           [System.Environment]::GetEnvironmentVariable("Path","Machine"),
           [System.Environment]::GetEnvironmentVariable("Path","User")
         ) -join ';')
-        Write-Host "User PATH updated"
+        Write-Host "PATH updated: `r`nPreviously $($existingPathData)`r`nNow $([System.Environment]::GetEnvironmentVariable("Path","Machine"))"

--- a/action.yml
+++ b/action.yml
@@ -35,5 +35,19 @@ runs:
         Start-Process -FilePath $downloadPath
         Write-Host "Pulsar Install completed"
 
-        $Env:PATH += ";$env:LOCALAPPDATA\Programs\Pulsar"
-        $env:Path = [System.Environment]::GetEnvironmentVariable("Path","Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path","User")
+        Write-Host "Adding Pulsar and PPM directories to User PATH"
+        $registryPath = 'Registry::HKEY_CURRENT_USER\Environment'
+
+        $existingUserPath = (Get-ItemProperty -Path $registryPath -Name path).Path
+        $newUserPath = @(
+          $existingMachinePath,
+          "$env:LOCALAPPDATA\Programs\Pulsar",
+          "$env:LOCALAPPDATA\Programs\Pulsar\resources\app\ppm\bin"
+        )
+        
+        Set-ItemProperty -Path $registryPath -Name path -Value (($newUserPath -join ';').replace(';;', ';'))
+        $env:Path = (@(
+          [System.Environment]::GetEnvironmentVariable("Path","Machine"),
+          [System.Environment]::GetEnvironmentVariable("Path","User")
+       ) -join ';')
+       Write-Host "User PATH updated"

--- a/action.yml
+++ b/action.yml
@@ -32,7 +32,7 @@ runs:
         $wc.DownloadFile($url, $downloadPath)
 
         Write-Host "Installing Pulsar - this may take awhile"
-        Start-Process -FilePath $downloadPath
+        Start-Process -FilePath $downloadPath -ArgumentList '/currentuser', '/S' -Wait
         Write-Host "Pulsar Install completed"
 
         Write-Host "Adding Pulsar and PPM directories to User PATH"

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,9 @@ runs:
         curl -L "https://download.pulsar-edit.dev/?os=intel_mac&type=mac_dmg" --output pulsar.dmg
         hdiutil attach pulsar.dmg
         sudo cp -rf /Volumes/Pulsar*/Pulsar.app /Applications
-        sudo ln -s /Applications/Pulsar.app/Contents/MacOS/Pulsar /usr/local/bin/pulsar
+        sudo mkdir -p /usr/local/bin/
+        sudo ln -s /Applications/Pulsar.app/Contents/Resources/pulsar.sh /usr/local/bin/pulsar
+        #sudo ln -s /Applications/Pulsar.app/Contents/Resources/app/ppm/bin/apm /usr/local/bin/ppm
     - if: runner.os == 'Windows'
       shell: pwsh
       run: |

--- a/action.yml
+++ b/action.yml
@@ -40,8 +40,8 @@ runs:
         $existingPathData = [System.Environment]::GetEnvironmentVariable("Path","Machine")
         $newPathData = @(
           $existingPathData,
-          "$env:LOCALAPPDATA\Programs\Pulsar",
-          "$env:LOCALAPPDATA\Programs\Pulsar\resources\app\ppm\bin"
+          "$env:LOCALAPPDATA\Programs\Pulsar\",
+          "$env:LOCALAPPDATA\Programs\Pulsar\resources\app\ppm\bin\"
         )
         
         [System.Environment]::SetEnvironmentVariable("Path", (($newPathData -join ';').replace(';;', ';')), [EnvironmentVariableTarget]::Machine )

--- a/action.yml
+++ b/action.yml
@@ -19,7 +19,6 @@ runs:
         curl -L "https://download.pulsar-edit.dev/?os=intel_mac&type=mac_dmg" --output pulsar.dmg
         hdiutil attach pulsar.dmg
         sudo cp -rf /Volumes/Pulsar*/Pulsar.app /Applications
-        xattr -cr /Applications/Pulsar.app/
         sudo ln -s /Applications/Pulsar.app/Contents/MacOS/Pulsar /usr/local/bin/pulsar
     - if: runner.os == 'Windows'
       shell: pwsh


### PR DESCRIPTION
Add the Pulsar install directory, and ppm bin directory to the user path - this should hopefully allow downstream steps to be able to shorthand `pulsar` instead of the full path