### PR TITLE
Add libsecret-1-0 to Linux install

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
     - if: runner.os == 'Linux'
       shell: bash
       run: |
-        sudo apt install -y libnotify4 libsecret-1-0
+        sudo apt install -y libnotify4
         curl -L "https://download.pulsar-edit.dev/?os=linux&type=linux_deb" --output pulsar.deb
         sudo dpkg -i pulsar.deb
 

--- a/action.yml
+++ b/action.yml
@@ -10,7 +10,7 @@ runs:
     - if: runner.os == 'Linux'
       shell: bash
       run: |
-        sudo apt install -y libnotify4
+        sudo apt install -y libnotify4 libsecret-1-0
         curl -L "https://download.pulsar-edit.dev/?os=linux&type=linux_deb" --output pulsar.deb
         sudo dpkg -i pulsar.deb
 


### PR DESCRIPTION
Ubuntu-latest (ubuntu-24.04 as of now) doesn't include libsecret as part of its installed packages

Per the [Ubuntu 22.04](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md) runner doc, it had `libsecret-1-dev`, however, I can't find a good reason to use `libsecret-1-dev` instead of `libsecret-1-0`